### PR TITLE
Add .gitlab-ci.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.exe
+cores/*/*.html
+cores/mame2003-plus/datmagic

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,20 @@
+stages:
+  - package
+
+.package-base:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:latest
+  stage: package
+  variables:
+    MEDIA_PATH: .media
+  script:
+    - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}/site/cores/mame2003-plus
+    - cd cores/mame2003-plus && make && ./datmagic && cd -
+    - cp -f cores/mame2003-plus/mame2003-plus.html ${MEDIA_PATH}/${CI_PROJECT_NAME}/site/cores/mame2003-plus
+    - cp -f index.html ${MEDIA_PATH}/${CI_PROJECT_NAME}/site
+  artifacts:
+    paths:
+    - ${MEDIA_PATH}
+    expire_in: 1 day
+
+libretro-package-any:
+  extends: .package-base

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# core-compatibility
+# RetroArch Core Compatibility
+
+- [Core Compatibility Lists]
+
+[Core Compatibility Lists]: https://buildbot.libretro.com/compatibility_lists/

--- a/cores/mame2003-plus/Makefile
+++ b/cores/mame2003-plus/Makefile
@@ -1,9 +1,29 @@
+TARGET := datmagic
+
+# Attempt to detect target platform
+ifeq '$(findstring ;,$(PATH))' ';'
+	UNAME := Windows
+else
+	UNAME := $(shell uname 2>/dev/null || echo Unknown)
+	UNAME := $(patsubst CYGWIN%,Cygwin,$(UNAME))
+	UNAME := $(patsubst MSYS%,MSYS,$(UNAME))
+	UNAME := $(patsubst MINGW%,MSYS,$(UNAME))
+endif
+
+# Add '.exe' extension on Windows platforms
+ifeq ($(UNAME), Windows)
+	TARGET := datmagic.exe
+endif
+ifeq ($(UNAME), MSYS)
+	TARGET := datmagic.exe
+endif
+
 CFLAGS := -O2 -Wall -Wextra
 
-all: datmagic
+all: $(TARGET)
 
 clean:
-	rm -f datmagic.exe
+	rm -f $(TARGET) mame2003-plus.html
 
-datmagic: datmagic.c
+$(TARGET): datmagic.c
 	$(CC) $(CFLAGS) -o $@ $<

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>RetroArch Core Compatibility</title>
+	</head>
+	<body>
+		<h1>RetroArch Core Compatibility</h1>
+		<ul>
+			<li><a href="cores/mame2003-plus/mame2003-plus.html">mame2003-plus</a></li>
+		</ul>
+	</body>
+</html>


### PR DESCRIPTION
This PR adds a `.gitlab-ci.yml` file, required for the generation of output html files via the new build infrastructure. In addition:

- The `datmagic` makefile has been updated to remove the `.exe` file extension on Unix platforms
- A placeholder `index.html` file has been added to provide easy access to the available compatibility lists